### PR TITLE
Tiny generated code guide fix

### DIFF
--- a/GENERATED_CODE.md
+++ b/GENERATED_CODE.md
@@ -73,7 +73,7 @@ struct Foo {
 
   private var _field2: String? = nil
   public var field2: String? {
-    get {return _field2 ?? "foo"}
+    get {return _field2 ?? "hello"}
     set {_field2 = newValue}
   }
 }


### PR DESCRIPTION
Example protobuf message field2's default value (probably) should be reflected in the example generated code.
